### PR TITLE
Fix possible username truncation in version 49

### DIFF
--- a/src/org/digiplex/mcsod/MCSignOnDoor.java
+++ b/src/org/digiplex/mcsod/MCSignOnDoor.java
@@ -50,12 +50,12 @@ import org.digiplex.common.TemplateFormatter.MalformedFormatException;
 
 public class MCSignOnDoor {
 	private static final Logger LOG = Logger.getLogger("McSod");
-	private static final String VERSION = "1.6.2";
+	private static final String VERSION = "1.6.4";
 	private static final int CURRENT_PROTOCOL_VERSION; //set in constructor below
 	
 	static { //static constructor
 		String protoversion = MCSignOnDoor.class.getPackage().getSpecificationVersion();
-		if (protoversion == null) protoversion = /****/ "74" /****/; //up to date protocol version - UPDATE MANIFEST TOO!
+		if (protoversion == null) protoversion = /****/ "78" /****/; //up to date protocol version - UPDATE MANIFEST TOO!
 		CURRENT_PROTOCOL_VERSION = Integer.parseInt(protoversion);
 	}
 	
@@ -793,6 +793,7 @@ public class MCSignOnDoor {
                                         case 60: //CASE 60: version 1.5, no change that I'm aware of
                                         case 61: //CASE 61: version 1.5.2, no change that I'm aware of
                                         case 74: //CASE 74: version 1.6.2, no change that I'm aware of
+                                        case 78: //CASE 78: version 1.6.4, no change that I'm aware of
 					{
 						in.read(inbyte, 2, 2); //read 16-byte number, message length
 						int len = parseChar(inbyte, 2);


### PR DESCRIPTION
There was a skipped byte (index-4) in the inbyte array.
Also, the copyOfRange math wasn't quite right and could result in the
truncation of a reported username (e.g. for an 8-character username)
I only fixed version 49, as that's the only version I have to test.
