### PR TITLE
Updated Protocol version number

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -3,5 +3,5 @@ Class-Path: .
 Created-By: 1.6.0_17 (Sun Microsystems Inc.)
 Main-Class: org.digiplex.mcsod.MCSignOnDoor
 Implementation-Vendor: Tustin2121
-Specification-Version: 60
+Specification-Version: 61
 

--- a/src/org/digiplex/mcsod/MCSignOnDoor.java
+++ b/src/org/digiplex/mcsod/MCSignOnDoor.java
@@ -57,7 +57,7 @@ public class MCSignOnDoor {
 	
 	static { //static constructor
 		String protoversion = MCSignOnDoor.class.getPackage().getSpecificationVersion();
-		if (protoversion == null) protoversion = /****/ "60" /****/; //up to date protocol version - UPDATE MANIFEST TOO!
+		if (protoversion == null) protoversion = /****/ "61" /****/; //up to date protocol version - UPDATE MANIFEST TOO!
 		CURRENT_PROTOCOL_VERSION = Integer.parseInt(protoversion);
 	}
 	


### PR DESCRIPTION
Updated protocol version number from 60 to 61. Prevents minecraft from thinking that MCSod is out of date.
